### PR TITLE
add gitlab ci template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,52 @@
+stages:
+  - test
+  - deploy
+
+before_script:
+  - cd style &&
+    python3 setup.py install &&
+    cd ..
+  - cd lexer &&
+    python3 setup.py install &&
+    cd ..
+  # update pythontex to 0.17-dev
+  - git clone https://github.com/gpoore/pythontex.git &&
+    cd pythontex/pythontex &&
+    echo 1 | python3 pythontex_install.py &&
+    cd ../..
+  # install julia dependency
+  - julia install_pkg.jl REQUIRE
+
+.test_template: &test_definition
+  script:
+    - julia pull_julia_code.jl
+    - julia runtests.jl
+
+Julia 1.0:
+  image: johnnychen94/juliabook:1.0
+  stage: test
+  <<: *test_definition
+
+Julia 1.1:
+  image: johnnychen94/juliabook:1.1
+  stage: test
+  <<: *test_definition
+
+Julia 1.2:
+  image: johnnychen94/juliabook:1.2
+  stage: test
+  <<: *test_definition
+
+Deploy:
+  image: johnnychen94/juliabook:stable
+  stage: deploy
+  script:
+    # compile the book
+    - julia pull_julia_code.jl
+    - lualatex book
+    - pythontex3 book
+    - biber book
+    - lualatex book
+  artifacts:
+    paths:
+      - "*.pdf"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ before_script:
     echo 1 | python3 pythontex_install.py &&
     cd ../..
   # install julia dependency
-  - julia install_pkg.jl REQUIRE
+  - julia install_pkgs.jl REQUIRE
 
 .test_template: &test_definition
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@ stages:
   - test
   - deploy
 
+# To initialize submodules you need to set variables
+# GIT_SUBMODULE_STRATEGY=recursive
+# in gitlab CI/CD page
 before_script:
   - cd style &&
     python3 setup.py install &&
@@ -37,6 +40,7 @@ Julia 1.2:
   stage: test
   <<: *test_definition
 
+# compile the book only when all tests pass
 Deploy:
   image: johnnychen94/juliabook:stable
   stage: deploy
@@ -49,4 +53,4 @@ Deploy:
     - lualatex book
   artifacts:
     paths:
-      - "*.pdf"
+      - "book.pdf"

--- a/install_pkgs.jl
+++ b/install_pkgs.jl
@@ -1,0 +1,76 @@
+# add and build julia packages
+# 
+# Usage:
+#   julia install_pkg.jl filename1 [filenames...]
+#
+# example of requirement
+#
+# Images
+# IJulia  1.12+
+# Flux  v"0.6+"
+# Zygote  master
+
+using Pkg
+try
+    using ProgressMeter
+catch 
+    Pkg.add("ProgressMeter")
+    using ProgressMeter
+end
+try
+    using Suppressor
+catch 
+    Pkg.add("Suppressor")
+    using Suppressor
+end
+
+Base.VersionNumber(version::VersionNumber) = version
+
+for filename in ARGS[1:end]
+    @showprogress for require in readlines(filename)
+        # skip comments
+        require = strip(require)
+        if startswith(require, "#") || isempty(require)
+            continue
+        end
+
+        println("") 
+        @info "add and build $require"
+
+        # parse name and version
+    	version_pos = findfirst(" ", require)
+        name = version_pos isa Nothing ? require : require[1:version_pos[1]-1]
+        name = strip(name) |> String
+        lowercase(name) == "julia" && continue # compat to REQUIRE
+        
+        if version_pos isa Nothing
+            version = nothing
+        else
+            version = strip(require[version_pos[2]+1:end])
+            try
+                version = VersionNumber(version)
+            catch ArgumentError
+                # url, `master`
+                nothing
+            end
+        end
+
+        # install package
+        if version isa Nothing
+            # Ijulia
+            @suppress Pkg.add(name)
+        elseif version isa VersionNumber
+            # Ijulia 1.12+
+            @suppress Pkg.add(PackageSpec(name = name, version = version))
+        elseif startswith(version, "#")
+            # IJulia #master
+            version = version[2:end] |> String
+            @suppress Pkg.add(PackageSpec(name = name, rev = version))
+        elseif startswith(version, "http")
+            # Ijulia https://github.com/JuliaLang/IJulia.jl
+            @suppress Pkg.add(PackageSpec(url = String(version)))
+        else
+            error("unsupported package format: $require")
+        end
+    end
+end


### PR DESCRIPTION
1. test the pulled codes against to different Julia version. (I use a very simple [docker image](https://github.com/johnnychen94/docker-juliabook) made by myself)
2. when all tests pass, compile the book
3. after compilation, a downloadable pdf file as an artifact is provided.

CI demo:
![image](https://user-images.githubusercontent.com/8684355/62013887-0cefd600-b1cc-11e9-85db-dd99ec83e843.png)

Please enlighten me if there's a better tool than `install_pkg.jl`.