### PR TITLE
set up a live CI demo on gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,14 @@ stages:
   - test
   - deploy
 
+variables:
+  # override DEPOT_PATH to install packages in the project
+  # folder, because gitlab can only cache files whthin it
+  JULIA_DEPOT_PATH: "$CI_PROJECT_DIR/.julia"
+cache:
+  paths:
+    - $JULIA_DEPOT_PATH
+
 # To initialize submodules you need to set variables
 # GIT_SUBMODULE_STRATEGY=recursive
 # in gitlab CI/CD page

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,11 +12,6 @@ before_script:
   - cd lexer &&
     python3 setup.py install &&
     cd ..
-  # update pythontex to 0.17-dev
-  - git clone https://github.com/gpoore/pythontex.git &&
-    cd pythontex/pythontex &&
-    echo 1 | python3 pythontex_install.py &&
-    cd ../..
   # install julia dependency
   - julia install_pkgs.jl REQUIRE
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tufte Algorithms Book Template
 
+[![pipeline status](https://gitlab.com/johnnychen94/tufte_algorithms_book/badges/master/pipeline.svg)](https://gitlab.com/johnnychen94/tufte_algorithms_book/commits/master)
+
 This book template provides a starting point upon which authors may freely build to generate their own textbook entirely in LaTeX.
 We used this setup for Algorithms for Optimization, and have continued to refine it for a new textbook on decision making under uncertainty.
 The template allows for the direct compilation of a print-ready PDF, including support for figures, examples, and exercises.

--- a/makefile
+++ b/makefile
@@ -1,14 +1,14 @@
 test:
-    julia --color=yes pull_julia_code.jl
-    julia --color=yes runtests.jl
+	julia --color=yes pull_julia_code.jl
+	julia --color=yes runtests.jl
 compile:
-    julia --color=yes pull_julia_code.jl
-    lualatex book
-    pythontex book
-    biber book
-    lualatex book
+	julia --color=yes pull_julia_code.jl
+	lualatex book
+	pythontex book
+	biber book
+	lualatex book
 clean:
-    find . -type f -name "*.aux" -exec rm -f {} \;
-    rm -f book.bbl book.blg book.bcf book.idx book.log book.out book.pytxcode book.run.xml book.toc
-    rm -f all_algorithm_blocks.jl all_juliaconsole_blocks.jl all_test_blocks.jl
-    rm -rf pythontex-files-book
+	find . -type f -name "*.aux" -exec rm -f {} \;
+	rm -f book.bbl book.blg book.bcf book.idx book.log book.out book.pytxcode book.run.xml book.toc
+	rm -f all_algorithm_blocks.jl all_juliaconsole_blocks.jl all_test_blocks.jl
+	rm -rf pythontex-files-book


### PR DESCRIPTION
There're four changes in this PR, there're all related to CI:

* fix a makefile error: The makefile introduced in #8 should use hard TAB instead of speces
* caching julia packages: adding and buiding julia packages in CI is time-consuming
* remove the installation of pythontex 0.17-dev in CI: I've installed it in the docker image :D

and most importantly,

* add a CI badge to README. (check the [README]( https://github.com/sisl/tufte_algorithms_book/blob/336c8e5308c4c5a12429789a5fe8eeb961d11d5f/README.md))

Unfortunately, it's not identically this repo which I don't have permission to.

If you want, I can give you the maintainer permission to [gitlab demo](https://gitlab.com/johnnychen94/tufte_algorithms_book); or you could fork and set up another demo repo 😄 