### PR TITLE
add CHAPTER option to makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Running `make test` pulls all the code and then runs all tests in `juliatest` bl
 ## Compilation
 
 * `make compile` compiles the whole book
+* `make compile CHAPTER = 'introduction chapter2\/introduction'` will comment out every `include` or `input` statement, except for `chapter/introduction` and `chapter/chapter2/introduction` where `chapter` can also be `appendix`. Requires `vim` to be installed.
 * `make clean` removes all generated files except `book.pdf`
 
 If you host your project under Gitlab, `.gitlab-ci.yml` is a CI/CD template to start with.

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ compile:
 ifdef CHAPTER
 	cp book.tex book.tex.bak
 	vim \
-	 -c ':/\\mainmatter/,/\\backmatter/s/\(^.*\\\(input\|include\).*$$\)/%\1/' \
+	 -c ':/\\begin{document}/,/\\end{document}/s/\(^.*\\\(input\|include\).*$$\)/%\1/' \
 	 $(foreach var,$(CHAPTER),-c ':g/\(chapter\|appendix\)\/$(var)/s/^.//' ) \
 	 -c :wq \
 	 book.tex

--- a/makefile
+++ b/makefile
@@ -1,12 +1,24 @@
+CHAPTER :=
 test:
 	julia --color=yes pull_julia_code.jl
 	julia --color=yes runtests.jl
 compile:
+ifdef CHAPTER
+	cp book.tex book.tex.bak
+	vim \
+	 -c ':/\\mainmatter/,/\\backmatter/s/\(^.*\\\(input\|include\).*$$\)/%\1/' \
+	 $(foreach var,$(CHAPTER),-c ':g/\(chapter\|appendix\)\/$(var)/s/^.//' ) \
+	 -c :wq \
+	 book.tex
+endif
 	julia --color=yes pull_julia_code.jl
 	lualatex book
 	pythontex book
 	biber book
 	lualatex book
+ifdef CHAPTER
+	mv book.tex.bak book.tex
+endif
 clean:
 	find . -type f -name "*.aux" -exec rm -f {} \;
 	rm -f book.bbl book.blg book.bcf book.idx book.log book.out book.pytxcode book.run.xml book.toc


### PR DESCRIPTION
This allows to compile only selected chapters via
```
make compile CHAPTER='<what-comes-after-"include|input{chapter|appendix/">'
```
note, that `/` has to be escaped as `\/`. Multiple chapters are separated by space. Depends on `vim` to be installed.
A makefile implementation of https://github.com/sisl/tufte_algorithms_book/issues/5#issuecomment-517837084.